### PR TITLE
UHF-6325: Replaced chatblock with leijuke.

### DIFF
--- a/conf/cmi/block.block.chatleijuke.yml
+++ b/conf/cmi/block.block.chatleijuke.yml
@@ -1,4 +1,4 @@
-uuid: 14acbd92-cc28-46a1-8271-0db64c191e1b
+uuid: ae5d34cd-03ac-4602-8486-26c10e027974
 langcode: en
 status: true
 dependencies:
@@ -7,17 +7,19 @@ dependencies:
     - system
   theme:
     - hdbt
-id: watsonchatbot
+id: chatleijuke
 theme: hdbt
 region: attachments
 weight: 0
 provider: null
-plugin: watson_chatbot
+plugin: chat_leijuke
 settings:
-  id: watson_chatbot
-  label: 'Watson chatbot'
+  id: chat_leijuke
+  label: 'Chat Leijuke Watson'
   label_display: '0'
   provider: helfi_platform_config
+  chat_title: Asunnonhakubotti
+  chat_selection: watson_chatbot
 visibility:
   request_path:
     id: request_path

--- a/conf/cmi/block.block.chatleijuke.yml
+++ b/conf/cmi/block.block.chatleijuke.yml
@@ -18,7 +18,7 @@ settings:
   label: 'Chat Leijuke Watson'
   label_display: '0'
   provider: helfi_platform_config
-  chat_title: Asunnonhakubotti
+  chat_title: 'Apartment search bot'
   chat_selection: watson_chatbot
 visibility:
   request_path:

--- a/conf/cmi/language/fi/block.block.chatleijuke.yml
+++ b/conf/cmi/language/fi/block.block.chatleijuke.yml
@@ -1,0 +1,2 @@
+settings:
+  chat_title: Asunnonhakubotti

--- a/conf/cmi/language/sv/block.block.chatleijuke.yml
+++ b/conf/cmi/language/sv/block.block.chatleijuke.yml
@@ -1,0 +1,2 @@
+settings:
+  chat_title: 'Lägenhet sök bot'


### PR DESCRIPTION
# [UHF-6325](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6325)
<!-- What problem does this solve? -->
Replaces chat blocks with leijuke.
## What was done
<!-- Describe what was done -->

* Replaced chat blocks with leijuke blocks.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6325-chat-via-leijuke`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works by visiting e.g. /fi/asuminen/vuokra-asunnot page and interacting with the chat leijuke.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
