### PR TITLE
UHF-7241: Updated Swedish translation of front page in the breadcrumb

### DIFF
--- a/conf/cmi/language/sv/metatag.metatag_defaults.front.yml
+++ b/conf/cmi/language/sv/metatag.metatag_defaults.front.yml
@@ -1,1 +1,1 @@
-label: Startsida
+label: Huvudsida


### PR DESCRIPTION
# [UHF-7241](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7241)
Swedish translation of front page is wrong in the breadcrumb.

## What was done
* Updated the translation of front page from Startsida to Huvudsida.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7241_asuminen-breadcrumb-translation-fix`
* Run `make drush-cim`
* Run `make drush-cr`

## How to test

* [ ] Check that front page in the breadcrumb on Swedish pages is Huvudsida instead of something else

## Designers review

* [x] This PR does not need designers review

## Other PRs
https://github.com/City-of-Helsinki/drupal-helfi-kuva/pull/116
https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/391
https://github.com/City-of-Helsinki/drupal-helfi-tyo-yrittaminen/pull/186
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/568
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/508
https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/181
https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/290

[UHF-7241]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ