### PR TITLE
UHF-8238: Disable old Watson chat app embed, add new one.

### DIFF
--- a/conf/cmi/block.block.ibmchatapp_watson_asuminen.yml
+++ b/conf/cmi/block.block.ibmchatapp_watson_asuminen.yml
@@ -20,7 +20,7 @@ settings:
   provider: helfi_platform_config
   hostname: 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
   engagementId: housing
-  tenantId: 'www-hel-fi- prod'
+  tenantId: 'www-hel-fi-prod'
   assistantId: housing
 visibility:
   request_path:

--- a/conf/cmi/block.block.ibmchatapp_watson_asuminen.yml
+++ b/conf/cmi/block.block.ibmchatapp_watson_asuminen.yml
@@ -1,25 +1,27 @@
-uuid: ae5d34cd-03ac-4602-8486-26c10e027974
+uuid: 69932451-ccaa-4586-bfa3-7873e30a42b0
 langcode: en
-status: false
+status: true
 dependencies:
   module:
     - helfi_platform_config
     - system
   theme:
     - hdbt
-id: chatleijuke
+id: ibmchatapp_watson_asuminen
 theme: hdbt
 region: attachments
 weight: 0
 provider: null
-plugin: chat_leijuke
+plugin: ibm_chat_app
 settings:
-  id: chat_leijuke
-  label: 'Chat Leijuke Watson'
+  id: ibm_chat_app
+  label: 'IBM Chat App Watson - Asuminen'
   label_display: '0'
   provider: helfi_platform_config
-  chat_title: 'Apartment search bot'
-  chat_selection: watson_chatbot
+  hostname: 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
+  engagementId: housing
+  tenantId: 'www-hel-fi- prod'
+  assistantId: housing
 visibility:
   request_path:
     id: request_path


### PR DESCRIPTION
# [UHF-8238](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8238)

## What was done
This PR disables old IBM Watson chatbot embeds and enables the new one.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8238-new-ibm-chatbots`
  * `make fresh`
* Run `make drush-cr`

## How to test
* [ ] Check that this feature works
  * Can't be fully tested yet because the applications need to be updated on IBM's side first
* [ ] Compare the [new block config](https://helfi-asuminen.docker.so/fi/asuminen/admin/structure/block) to the disabled "ChatLeijuke" blocks and the Platform config libraries file: https://github.com/City-of-Helsinki/drupal-helfi-platform-config/blob/3.x/helfi_platform_config.libraries.yml
  * The pages the block appears on should be the same
  * The tentantID and assistandID parameters should be the same  
* [ ] Check that code follows our standards
  * Check the YML files and make sure there's nothing weird there

## Designers review
* [x] This PR does not need designers review

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/426
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/550

[UHF-8238]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ