### PR TITLE
UHF-8437: Disabled dblog module

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -18,7 +18,6 @@ module:
   content_lock_timeout: 0
   crop: 0
   datetime: 0
-  dblog: 0
   diff: 0
   dynamic_page_cache: 0
   easy_breadcrumb: 0


### PR DESCRIPTION
# [UHF-8437](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8437)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Disabled dblog and watchdog view if it was on as well.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8437_disable_dblog`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that dblog is no longer enabled on the site.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-asuminen/pull/241
* https://github.com/City-of-Helsinki/drupal-helfi-tyo-yrittaminen/pull/236
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/373
* https://github.com/City-of-Helsinki/drupal-helfi-kuva/pull/169
* https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/255
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/579


[UHF-8437]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ