### PR TITLE
UHF-8802: Non-linguistic URLs

### DIFF
--- a/conf/cmi/helfi_proxy.settings.yml
+++ b/conf/cmi/helfi_proxy.settings.yml
@@ -6,3 +6,4 @@ prefixes:
   fi: asuminen
   sv: boende
   ru: housing
+  zxx: housing

--- a/public/sites/default/staging.settings.php
+++ b/public/sites/default/staging.settings.php
@@ -7,5 +7,6 @@ $config['helfi_proxy.settings']['prefixes'] = [
   'fi' => 'staging-asuminen',
   'sv' => 'staging-boende',
   'ru' => 'staging-housing',
+  'zxx' => 'staging-housing',
 ];
 

--- a/public/sites/default/testing.settings.php
+++ b/public/sites/default/testing.settings.php
@@ -7,4 +7,5 @@ $config['helfi_proxy.settings']['prefixes'] = [
   'fi' => 'test-asuminen',
   'sv' => 'test-boende',
   'ru' => 'test-housing',
+  'zxx' => 'test-housing',
 ];


### PR DESCRIPTION
# [UHF-8802](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8802)
<!-- What problem does this solve? -->

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8802`
* Run `drush updb` and `drush cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure sitemap.xml works through `/housing/sitemap.xml` and the page does not get redirected to something else


[UHF-8802]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ