### PR TITLE
UHF-10647: Enabling helfi_recommendations

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -23,6 +23,7 @@ module:
   easy_breadcrumb: 0
   editor: 0
   editoria11y: 0
+  elasticsearch_connector: 0
   encrypt: 0
   entity: 0
   entity_reference_revisions: 0
@@ -81,6 +82,7 @@ module:
   helfi_platform_config_base: 0
   helfi_proxy: 0
   helfi_react_search: 0
+  helfi_recommendations: 0
   helfi_tfa: 0
   helfi_toc: 0
   helfi_tpr: 0
@@ -141,6 +143,7 @@ module:
   rest: 0
   role_delegation: 0
   scheduler: 0
+  search_api: 0
   select2: 0
   serialization: 0
   simple_sitemap: 0


### PR DESCRIPTION
# [UHF-10647](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647)

## What was done

Enables `helfi_recommendations` via config. Attempts to enable via an install hook in helfi_platform_config kept failing in instances where `search_api` needs to be enabled as well (this is explained in more depth in this core issue: https://www.drupal.org/project/drupal/issues/2825358), so resorting to this manual approach instead.

## How to install and test

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10647_enable_recommendations`
  * `make fresh`
  * [ ] `helfi_recommendations` was enabled as part of config import without errors

## Other PRs

No need to test in all instances, but feel free to pick additional ones if you feel like it:

* https://github.com/City-of-Helsinki/drupal-helfi-tyo-yrittaminen/pull/555
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/842
* https://github.com/City-of-Helsinki/drupal-helfi-kuva/pull/507
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/1092
* https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/722
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/1034
* https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/797


[UHF-10647]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ