### PR TITLE
UHF-11611: Add MATOMO_SITE_ID variable to all.settings.php file

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -44,6 +44,7 @@ $additionalEnvVars = [
   'TUNNISTAMO_ENVIRONMENT_URL',
   'SENTRY_DSN',
   'SENTRY_ENVIRONMENT',
+  'MATOMO_SITE_ID'
   // 'AMQ_BROKERS',
   // 'AMQ_USER',
   // 'AMQ_PASSWORD',


### PR DESCRIPTION
# [UHF-11611](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11611)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add MATOMO_SITE_ID variable to all.settings.php file

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11611`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

[UHF-11611]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ