### PR TITLE
UHF-12605: Add MATOMO_SITE_ID

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -32,6 +32,7 @@ services:
       DRUPAL_VARNISH_PORT: 6081
       REDIS_HOST: redis
       PROJECT_NAME: "${PROJECT_NAME}"
+      MATOMO_SITE_ID: "${MATOMO_SITE_ID:-}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
       - "${DRUPAL_HOSTNAME}:host-gateway"


### PR DESCRIPTION
# [UHF-12605](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12605)

Make enabling matomo feasible locally.

Check testing info here: https://github.com/City-of-Helsinki/drupal-hdbt/pull/1506

[UHF-12605]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ